### PR TITLE
Update Exa env comments

### DIFF
--- a/env.tpl
+++ b/env.tpl
@@ -64,9 +64,9 @@ FIRECRAWL_API_KEY=
 # (Optional) Server-side Firecrawl API Proxy URL. Default, `https://api.firecrawl.dev`
 FIRECRAWL_API_BASE_URL=
 
-# (Optional) Server-side Firecrawl API Key (Required for server API calls)
+# (Optional) Server-side Exa API Key (Required for server API calls)
 EXA_API_KEY=
-# (Optional) Server-side Firecrawl API Proxy URL. Default, `https://api.exa.ai`
+# (Optional) Server-side Exa API Proxy URL. Default, `https://api.exa.ai`
 EXA_API_BASE_URL=
 
 # (Optional) Server-side Bocha API Key (Required for server API calls)


### PR DESCRIPTION
## Summary
- fix naming in Exa API variables

## Testing
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68421100a854832eac9180499c6f8a00