### PR TITLE
Add Word export option for final report

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "build:standalone": "cross-env NEXT_PUBLIC_BUILD_MODE=standalone next build",
     "build:export": "cross-env NEXT_PUBLIC_BUILD_MODE=export next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^1.2.10",
@@ -95,6 +96,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "babel-plugin-react-compiler": "19.1.0-rc.1",
+    "vitest": "^1.5.1",
     "cross-env": "^7.0.3",
     "eslint": "^9",
     "eslint-config-next": "15.1.7",

--- a/src/components/Research/FinalReport/index.tsx
+++ b/src/components/Research/FinalReport/index.tsx
@@ -37,6 +37,7 @@ import { useTaskStore } from "@/store/task";
 import { useKnowledgeStore } from "@/store/knowledge";
 import { getSystemPrompt } from "@/utils/deep-research/prompts";
 import { downloadFile } from "@/utils/file";
+import { markdownToDoc } from "@/utils/markdown";
 
 const MagicDown = dynamic(() => import("@/components/MagicDown"));
 const Artifact = dynamic(() => import("@/components/Artifact"));
@@ -133,6 +134,16 @@ function FinalReport() {
     toast.message(t("research.common.addToKnowledgeBaseTip"));
   }
 
+  function handleDownloadWord() {
+    // markdownToDoc returns HTML that Word can read as a legacy .doc file
+    const docHtml = markdownToDoc(getFinakReportContent());
+    downloadFile(
+      docHtml,
+      `${taskStore.title}.doc`,
+      "application/msword;charset=utf-8"
+    );
+  }
+
   async function handleDownloadPDF() {
     const originalTitle = document.title;
     document.title = taskStore.title;
@@ -226,6 +237,12 @@ function FinalReport() {
                       >
                         <FileText />
                         <span>Markdown</span>
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        onClick={() => handleDownloadWord()}
+                      >
+                        <FileText />
+                        <span>Word</span>
                       </DropdownMenuItem>
                       <DropdownMenuItem
                         className="max-md:hidden"

--- a/src/utils/markdown.test.ts
+++ b/src/utils/markdown.test.ts
@@ -1,0 +1,10 @@
+import { markdownToDoc } from './markdown';
+import { describe, it, expect } from 'vitest';
+
+describe('markdownToDoc', () => {
+  it('wraps parsed HTML in a doc structure', () => {
+    const doc = markdownToDoc('# Hello');
+    expect(doc.startsWith('<!DOCTYPE html>')).toBe(true);
+    expect(doc).toContain('<h1 id="hello">Hello</h1>');
+  });
+});

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -1,0 +1,8 @@
+import { marked } from "marked";
+
+export function markdownToDoc(markdown: string): string {
+  const html = marked.parse(markdown);
+  // Word can open an HTML document saved with a ".doc" extension.
+  // This function returns that minimal HTML wrapper.
+  return `<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>${html}</body></html>`;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {},
+});


### PR DESCRIPTION
## Summary
- add `markdownToDoc` utility
- convert final report to Word via `markdownToDoc`
- add vitest with simple unit test
- clarify that HTML is saved with `.doc` extension for Word export

## Testing
- `pnpm install --ignore-scripts` *(fails: `ERR_PNPM_FETCH_403`)*
- `pnpm exec vitest run` *(fails: `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL`)*


------
https://chatgpt.com/codex/tasks/task_e_68422495a740832eb7b4aade094e3086